### PR TITLE
フォーマット方法を変更

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ function resolveTargetDateJST(): string {
   if (argIndex >= 0 && process.argv[argIndex + 1]) {
     const v = process.argv[argIndex + 1];
     if (v === 'today') return jst.toISOString().slice(0, 10);
-    if (v === 'tomorrow') { jst.setDate(jst.getDate() + 1); return jst.toISOString().slice(0, 10); }
+    if (v === 'tomorrow') { jst.setDate(jst.getDate() + 1); return jst.toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' }); }
     return v;
   }
   if (envOverride) return envOverride;


### PR DESCRIPTION
resolveTargetDateJST() 内で toISOString() を使っていたため、JSTで取得した日付が UTC に変換され、Slack通知に 前日 のタスクが出てしまう問題を修正
toLocaleDateString('en-CA', { timeZone: 'Asia/Tokyo' }) を利用して、JST基準で YYYY-MM-DD を生成するように変更